### PR TITLE
NodeMCU-PMS7003 Hardware Guide and Code

### DIFF
--- a/MadSensorsPMS7003/MadSensorsPMS7003.ino
+++ b/MadSensorsPMS7003/MadSensorsPMS7003.ino
@@ -1,0 +1,54 @@
+// MadSensors - Send PMS7003 Data Example
+//
+// Authors: Jose Zorrilla <jose@madsensors.com>, Brendan Munoz <brenmun00@gmail.com>
+// Website: https://madsensors.com
+// Description: This example reads the PM 1.0, 2.5 and 10.0 data from a
+// This sketch is only to show how to use the PMS7003 with the MadSensors library for ESP8266
+// The "pms.h" source code is based on the following Tutorial by Mr. Alam from: https://how2electronics.com/interfacing-pms5003-air-quality-sensor-arduino/#PMS5003_Air_Quality_Sensor
+// Variables such as TOKEN, WIFISSID, WIFIPASS and DEVICE_NAME have been omitted and can be defined manually in the "sensitive_data.h" header
+
+#include <MadSensors-esp8266.h>
+#include <SoftwareSerial.h>
+#include "sensitive_data.h"
+#include "pms.h"
+
+// Assign D1 and D2 to pms7003 serial port
+SoftwareSerial pmsSerial(4, 5);
+
+// Create the MadSensors object
+MadSensor madSensor(DEVICE_NAME, TOKEN);
+
+long lastPing = 0;
+void setup()
+{
+  // Connect to the WiFi network
+  madSensor.connectWifi(WIFISSID, WIFIPASS);
+  pmsSerial.begin(9600);
+}
+void loop()
+{
+  // Send a value every 30 seconds
+  if ((millis() - lastPing) > 30000)
+   {  
+    // Read PM 1.0, 2.5 and 10.0 data
+    if (readPMSdata(&pmsSerial)){
+    pms10_particle_data =data.particles_10um; //1.0 um
+    pms25_particle_data =data.particles_25um; //2.5 um
+    pms100_particle_data =data.particles_100um; //20.0 um
+    }
+    // Add pm 1.0, 2.5 and 10.0 particle data to 
+    madSensor.addNewValue("pm_1", pms10_particle_data);
+    madSensor.addNewValue("pm_2_5", pms25_particle_data);
+    madSensor.addNewValue("pm_10", pms100_particle_data);
+
+    // Shows the payload
+    Serial.print("JSON Payload: ");
+    Serial.println(madSensor.getPOSTrequest());
+
+    // Send the value to the MadSensor server
+    Serial.print("Server Reply: ");
+    Serial.println(madSensor.sendAll());
+
+    lastPing = millis();
+   }
+}

--- a/MadSensorsPMS7003/pms.h
+++ b/MadSensorsPMS7003/pms.h
@@ -1,0 +1,57 @@
+// Functions to Interface with the PMS7005 were provided from the following tutorial created by Mr. Alam: https://how2electronics.com/interfacing-pms5003-air-quality-sensor-arduino/#Source_CodeProgram 
+
+struct pms7003data {
+  uint16_t framelen;
+  uint16_t pm10_standard, pm25_standard, pm100_standard;
+  uint16_t pm10_env, pm25_env, pm100_env;
+  uint16_t particles_03um, particles_05um, particles_10um, particles_25um, particles_50um, particles_100um;
+  uint16_t unused;
+  uint16_t checksum;
+};
+
+struct pms7003data data;
+uint16_t pms10_particle_data;
+uint16_t pms25_particle_data;
+uint16_t pms100_particle_data;
+
+
+boolean readPMSdata(Stream *s) {
+  if (! s->available()) {
+    return false;
+  }
+  
+  // Read a byte at a time until we get to the special '0x42' start-byte
+  if (s->peek() != 0x42) {
+    s->read();
+    return false;
+  }
+ 
+  // Now read all 32 bytes
+  if (s->available() < 32) {
+    return false;
+  }
+    
+  uint8_t buffer[32];    
+  uint16_t sum = 0;
+  s->readBytes(buffer, 32);
+ 
+  // get checksum ready
+  for (uint8_t i=0; i<30; i++) {
+    sum += buffer[i];
+  }
+  
+  // The data comes in endian'd, this solves it so it works on all platforms
+  uint16_t buffer_u16[15];
+  for (uint8_t i=0; i<15; i++) {
+    buffer_u16[i] = buffer[2 + i*2 + 1];
+    buffer_u16[i] += (buffer[2 + i*2] << 8);
+  }
+ 
+  memcpy((void *)&data, (void *)buffer_u16, 30);
+ 
+  if (sum != data.checksum) {
+    Serial.println("Checksum failure");
+    return false;
+  }
+  return true;
+}

--- a/MadSensorsPMS7003/sensitive_data.h
+++ b/MadSensorsPMS7003/sensitive_data.h
@@ -1,0 +1,18 @@
+// MadSensors Token (Must be created using the MadSensors platform)
+#ifndef TOKEN
+#define TOKEN "INSERT_HERE"
+#endif
+
+// Your WiFi Credentials (replace with your WiFi credentials)
+#ifndef WIFISSID
+#define WIFISSID 
+#endif
+
+#ifndef WIFIPASS
+#define WIFIPASS "INSERT_HERE"
+#endif
+
+// Device Name (Must be created using the MadSensors platform)
+#ifndef DEVICE_NAME
+#define DEVICE_NAME "INSERT_HERE"
+#endif

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Where:
 For more information about the PMS7003 sensor, the datasheet can be found [here](https://download.kamami.com/p564008-p564008-PMS7003%20series%20data%20manua_English_V2.5.pdf).
 
 ## Connecting the PMS7003 to the NodeMCU
-The PMS7003 datasheet provides a circuit diagram of the PMS7003 connected to a generic Host MCU. This is how the sensor will be connected to the NodeMCU, with some minor modifications. For this project, only VCC, GND, RX and TX will be needed. Therefore, the pins being used on the NodeMCU will be Vin (5V), GND and D1 (GPIO) as well as D2 (GPIO) for the RX and TX pins. From this, the NodeMCU and the PMS7003 should be ready to use with the provided code.
+The PMS7003 datasheet provides a circuit diagram of the PMS7003 connected to a generic Host MCU. This is how the sensor will be connected to the NodeMCU, with some minor modifications. For this project, only VCC, GND, RX and TX will be needed. Therefore, the pins being used on the NodeMCU will be Vin (5V), GND and D1 (GPIO4) as well as D2 (GPIO5) for the RX and TX pins. From this, the NodeMCU and the PMS7003 should be ready to use with the provided code.
 
 ![image](https://user-images.githubusercontent.com/49784557/111967222-e4101780-8b4b-11eb-9d5e-29a14caffb67.png)
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # MadSensors-NodeMCU-PMS7003
-MadSensors - Plantower PMS 7003 particulate matter sensor
+
+## Introduction
+This project utilises a Plantower PMS7003 particulate matter sensor and a NodeMCU ESP8266-12E to remotely send live air-quality data to MadSensor's "NodeMCUBrendan" Dashboard. The data consists of PM 1.0, PM 2.5 and PM 10.0 particle readings which are plotted overtime at 30 second intervals. This file will go throught the steps on how to set up both the NodeMCU and the PMS7003 to then be used with the provided code.
+
+## NodeMCU with Arduino IDE
+For this project, the NodeMCU will be programmed in the Arduino IDE and as such ESP8266-12E suppourt must be installed. The steps to do so are as follows:
+- In the Arduino IDE: select "File > Preferences" and paste <http://arduino.esp8266.com/stable/package_esp8266com_index.json> into the "Additional Boards Manager URLs:" field then click "OK".
+![image](https://user-images.githubusercontent.com/49784557/111945605-1e6abc00-8b2e-11eb-8752-3b1e4bd85be9.png)
+- From this, select "Tools > Board > Boards Manager..." to open the Boards Manager to then search and install "ESP8266 by ESP8266 Community"
+![image](https://user-images.githubusercontent.com/49784557/111949097-35141180-8b34-11eb-961e-af17a872858a.png)
+Now that NodeMCU suppourt is installed, the "ESP-12E Module" Board can be selected by going to "Tools > Board > NodeMCU 1.0 (ESP-12E Module)".
+
+## Plantower PMS7003
+The PMS7003 is a particle concentration sensor which can be used to obtain the number of suspended particles in the air. This is accomplished using laser scattering, in which a laser is used to radiate the suspending particles in the air and the curve of scattering light change overtime can be found. From this, equivalent particle diameter and the number of particles with different diameter per unit volume can be calculated using the sensor's built-in microprocessor. The datasheet for this sensor provides the following functional diagram:
+![image](https://user-images.githubusercontent.com/49784557/111959957-3dc01400-8b43-11eb-89e6-76f510b0dc74.png)
+
+The Pin Definitions for the PMS7003 can be found in its datasheet:
+
+![image](https://user-images.githubusercontent.com/49784557/111960871-6563ac00-8b44-11eb-892d-cef19db42e58.png)
+
+Where:
+- Pin 1 and 2 are 5V
+- Pin 3 and 4 are GND
+- Pins 6 and 8 are not connected
+- Pin 7 and 9 are the Serial Port RX and TX, and
+- Pin 10 and 5 are SET and RESET 
+
+For more information about the PMS7003 sensor, the datasheet can be found [here](https://download.kamami.com/p564008-p564008-PMS7003%20series%20data%20manua_English_V2.5.pdf).
+
+## Connecting the PMS7003 to the NodeMCU
+The PMS7003 datasheet provides a circuit diagram of the PMS7003 connected to a generic Host MCU. This is how the sensor will be connected to the NodeMCU, with some minor modifications. For this project, only VCC, GND, RX and TX will be needed. Therefore, the pins being used on the NodeMCU will be Vin (5V), GND and D1 (GPIO) as well as D2 (GPIO) for the RX and TX pins. From this, the NodeMCU and the PMS7003 should be ready to use with the provided code.
+
+![image](https://user-images.githubusercontent.com/49784557/111967222-e4101780-8b4b-11eb-9d5e-29a14caffb67.png)
+
+![image](https://user-images.githubusercontent.com/49784557/111967713-7adcd400-8b4c-11eb-8498-7f48905b4c9f.png)


### PR DESCRIPTION
- Added a guide to setup NodeMCU support for the Arduino IDE
- Added information about the PMS7003 sensor provided in its datasheet
- Added a guide to connect the PMS7003 and NodeMCU and provided pin allocations used in the code
- Linked datasheet
- Added NodeMCU-PMS7003 code and PMSx003 interfacing header
- Credited sources for PMSx003 interfacing functions in comments of the code